### PR TITLE
ruby versionを2.7.2に変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.7.0'
+ruby '2.7.2'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~>6.0.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,7 +210,7 @@ DEPENDENCIES
   uglifier
 
 RUBY VERSION
-   ruby 2.7.0p0
+   ruby 2.7.2p137
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
## 実装の背景・目的

herokuのruby2.7.0のサポートが切れていたため2.7.2にアップグレードするため

## やったこと

Gemfileのrubyバージョンを2.7.2に変更してbundle installしました。

## キャプチャ

## 補足
https://giftee-inc.slack.com/archives/C01K38SS9C3/p1611121110022200