### PR TITLE
trash_day.rbの実装

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -29,7 +29,7 @@ class WebhookController < ApplicationController
               FetchWeather.get_weather_message(zip_code: "251-0875")
           elsif event.message['text'] == "大学の天気"
               FetchWeather.get_weather_message(zip_code: "194-0013")
-          elsif event.message['text'] == "ゴミ収集日"
+          elsif event.message['text'] == "ゴミ収集日程"
               TrashDay.get_trash_message()
           else
               "ちょっと何言ってるか分からないなー"

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -29,6 +29,8 @@ class WebhookController < ApplicationController
               FetchWeather.get_weather_message(zip_code: "251-0875")
           elsif event.message['text'] == "大学の天気"
               FetchWeather.get_weather_message(zip_code: "194-0013")
+          elsif event.message['text'] == "ゴミ収集日"
+              TrashDay.get_trash_message()
           else
               "ちょっと何言ってるか分からないなー"
           end

--- a/app/models/trash_day.rb
+++ b/app/models/trash_day.rb
@@ -14,20 +14,24 @@ class TrashDay
   end
 
   def self.get_trash_of_today
-    today = Date.today
+    today = Time.zone.today
     case today.wday
     when 1, 4
       "可燃ごみ、ビン"
     when 2
       diff = today - BASE_DAY_RECYCLABLE_WASTE
-      diff % 14 == 0 ? "資源" : "不燃ごみ、プラスチック、本、雑がみ"
+      isEveryOtherWeek(diff) ? "資源" : "不燃ごみ、プラスチック、本、雑がみ"
     when 3
       "プラスチック、油、特定品目"
     when 5
       diff = today - BASE_DAY_PLASTIC_BOTTLE
-      diff % 14 == 0 ? "ペットボトル" : "カン、なべ類"
+      isEveryOtherWeek(diff) ? "ペットボトル" : "カン、なべ類"
     else
       "今日はゴミの回収はありません。"
     end
+  end
+
+  def isEveryOtherWeek(diff)
+    diff % 14 == 0
   end
 end

--- a/app/models/trash_day.rb
+++ b/app/models/trash_day.rb
@@ -1,0 +1,33 @@
+class TrashDay
+
+  TRASH_INFO_URL = "https://www.city.fujisawa.kanagawa.jp/kankyo-j/kurashi/gomi/shushubi/nittei/r23b.html"
+  BASE_DAY_RECYCLABLE_WASTE = Date.new(2021, 1, 5).freeze
+  BASE_DAY_PLASTIC_BOTTLE = Date.new(2021, 1, 8).freeze
+
+  def self.get_trash_message
+    <<~MESSAGE.chomp
+      今日の収集品目：
+      #{get_trash_of_today}\n
+      各品目の収集日程はこちら：
+      #{TRASH_INFO_URL}
+    MESSAGE
+  end
+
+  def self.get_trash_of_today
+    today = Date.today
+    case today.wday
+    when 1, 4
+      "可燃ごみ、ビン"
+    when 2
+      diff = today - BASE_DAY_RECYCLABLE_WASTE
+      diff % 14 == 0 ? "資源" : "不燃ごみ、プラスチック、本、雑がみ"
+    when 3
+      "プラスチック、油、特定品目"
+    when 5
+      diff = today - BASE_DAY_PLASTIC_BOTTLE
+      diff % 14 == 0 ? "ペットボトル" : "カン、なべ類"
+    else
+      "今日はゴミの回収はありません。"
+    end
+  end
+end


### PR DESCRIPTION
## 実装の背景・目的
「ゴミ収集日」と入力すると、その日のゴミ収集品目と、詳細情報のURLを出力すること。

## やったこと
- [x] trash_day.rbの実装
- [x] webhook_controller.rbについて、「ゴミ収集日」の入力に対応するようにelsif文を追加

## キャプチャ
https://giftee-inc.slack.com/archives/C01K38SS9C3/p1611549203101100

## 補足
ゴミ収集日程の詳細情報のURL：
https://www.city.fujisawa.kanagawa.jp/kankyo-j/kurashi/gomi/shushubi/nittei/r23b.html
