### PR TITLE
Feature/fix weather_response.rb

### DIFF
--- a/app/models/trash_day.rb
+++ b/app/models/trash_day.rb
@@ -31,7 +31,7 @@ class TrashDay
     end
   end
 
-  def isEveryOtherWeek(diff)
+  def self.isEveryOtherWeek(diff)
     diff % 14 == 0
   end
 end

--- a/app/models/weather_response.rb
+++ b/app/models/weather_response.rb
@@ -39,7 +39,7 @@ class WeatherResponse
 
   def get_time_text(dt)
     jpdt_from = dt
-    datetime_from = Time.at(jpdt_from)
+    datetime_from = Time.zone.at(jpdt_from)
     datetime_from.strftime("%H時")
   end
 

--- a/app/models/weather_response.rb
+++ b/app/models/weather_response.rb
@@ -38,8 +38,8 @@ class WeatherResponse
   end
 
   def get_time_text(dt)
-    jpdt_from = dt
-    datetime_from = Time.zone.at(jpdt_from)
+    jpdt_from = dt + 9 * 60 * 60
+    datetime_from = Time.at(jpdt_from)
     datetime_from.strftime("%H時")
   end
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -83,6 +83,7 @@ test:
 #
 production:
   <<: *default
-  database: ruby-getting-started_production
-  username: ruby-getting-started
-  password: <%= ENV['RUBY-GETTING-STARTED_DATABASE_PASSWORD'] %>
+  database: <%= ENV['DATABASE_NAME'] %>
+  username: <%= ENV['DATABASE_USER_NAME'] %>
+  password: <%= ENV['DATABASE_USER_PASSWORD'] %>
+  host: <%= ENV['DATABASE_HOST'] %>


### PR DESCRIPTION
## 実装の背景・目的
天気予報の表示について、heroku上で実行すると時刻がUTCで表示されてしまうことがわかったので、日本時間に修正すること。

## やったこと
weather_response.rbの41行目について、dtがUTCで取得されるため、dtに9時間加算する処理を書いた。

## キャプチャ

## 補足
